### PR TITLE
remove unneeded "bottle :unneeded" from jardiff.rb

### DIFF
--- a/jardiff.rb
+++ b/jardiff.rb
@@ -4,8 +4,6 @@ class Jardiff < Formula
   url "https://github.com/scala/jardiff/releases/download/v1.6.0/jardiff.jar" #, using => :nounzip
   sha256 "a7c068d9880711ce7684be23cff2b07e61428c9dfe70fdd644663f1347eefbd6"
 
-  bottle :unneeded
-
   depends_on "openjdk@11"
 
   def install


### PR DESCRIPTION
when I brew upgrade, I'm getting:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the retronym/formulas tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/retronym/homebrew-formulas/jardiff.rb:7
```

so I guess they want us to do this.